### PR TITLE
Update deprecated touches for touchscreenPlatform

### DIFF
--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -33,6 +33,7 @@ type DefaultInternalHandler struct {
 	cursorOffset  map[string]image.Point
 
 	touchscreenPlatform bool
+	touchIDs            []ebiten.TouchID
 }
 
 var InternalUIHovered = false
@@ -56,14 +57,14 @@ var InputHandler *DefaultInternalHandler = &DefaultInternalHandler{
 
 // Update updates the input system. This is called by the UI.
 func (handler *DefaultInternalHandler) Update() {
-	touches := ebiten.TouchIDs()
+	handler.touchIDs = ebiten.AppendTouchIDs(handler.touchIDs[:0])
 	if len(touches) > 0 {
 		handler.isTouched = true
 	}
 	if handler.isTouched {
 		if len(touches) > 0 {
 			handler.LeftMouseButtonPressed = true
-			handler.CursorX, handler.CursorY = ebiten.TouchPosition(touches[0])
+			handler.CursorX, handler.CursorY = ebiten.TouchPosition(handler.touchIDs[0])
 		} else {
 			handler.LeftMouseButtonPressed = false
 			handler.isTouched = false


### PR DESCRIPTION
Updates deprecated `ebiten.TouchIDs()`  to use AppendTouchIDs instead (deprecated after v2.2.)

No breaking changes, tested in mobile browser