### PR TITLE
Add a max width & height property to Container struct

### DIFF
--- a/widget/container.go
+++ b/widget/container.go
@@ -216,12 +216,22 @@ func (c *Container) PreferredSize() (int, int) {
 		}
 	}
 
-	// If the set MinHeight or MinWidth are greater than calculated, use that
+	// If w & h are less than the Min values, use the Min values
 	if c.widget != nil && h < c.widget.MinHeight {
 		h = c.widget.MinHeight
 	}
 	if c.widget != nil && w < c.widget.MinWidth {
 		w = c.widget.MinWidth
+	}
+
+	// If w & h are greater than the Max values (and they are set), use the Max values
+	if c.widget != nil && (c.widget.MaxHeight != 0 || c.widget.MaxWidth != 0) {
+		if h > c.widget.MaxHeight {
+			h = c.widget.MaxHeight
+		}
+		if w > c.widget.MaxWidth {
+			w = c.widget.MaxWidth
+		}
 	}
 
 	return w, h

--- a/widget/container_test.go
+++ b/widget/container_test.go
@@ -72,6 +72,44 @@ func TestContainer_SetupInputLayer(t *testing.T) {
 	m.AssertExpectations(t)
 }
 
+func TestContainer_MinMaxWidthHeight(t *testing.T) {
+	is := is.New(t)
+	w := NewWidget()
+	is.Equal(w.MinWidth, 0)
+	is.Equal(w.MinHeight, 0)
+	is.Equal(w.MaxWidth, 0)
+	is.Equal(w.MaxHeight, 0)
+	m := controlMock{}
+	m.On("GetWidget").Maybe().Return(w)
+	m.On("PreferredSize").Maybe().Return(50, 50)
+	m.On("SetLocation", mock.Anything).Maybe()
+	m.On("Render", mock.Anything, mock.Anything)
+
+	c := newContainer(t,
+		ContainerOpts.WidgetOpts(
+			WidgetOpts.MinSize(100, 100),
+		))
+	c.AddChild(&m)
+
+	width, height := c.PreferredSize()
+	is.Equal(width, 100)
+	is.Equal(height, 100)
+
+	// setting max size should not affect preferred size
+	c = newContainer(t,
+		ContainerOpts.WidgetOpts(
+			WidgetOpts.MaxSize(200, 200),
+		))
+	c.AddChild(&m)
+
+	width, height = c.PreferredSize()
+	is.Equal(width, 0)
+	is.Equal(height, 0)
+
+	render(c, t)
+	m.AssertExpectations(t)
+}
+
 func (c *controlMock) GetWidget() *Widget {
 	args := c.Called()
 	if arg, ok := args.Get(0).(*Widget); ok {

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -26,11 +26,13 @@ type Widget struct {
 	// GridLayoutData to be used.
 	LayoutData interface{}
 
-	// The minimum width for this Widget
+	// The minimum and maximum width for this Widget
 	MinWidth int
+	MaxWidth int
 
-	// The minimum height for this Widget
+	// The minimum and maximum height for this Widget
 	MinHeight int
+	MaxHeight int
 
 	// Disabled specifies whether the widget is disabled, whatever that means. Disabled widgets should
 	// usually render in some sort of "greyed out" visual state, and not react to user input.
@@ -409,6 +411,13 @@ func (o WidgetOptions) MinSize(minWidth int, minHeight int) WidgetOpt {
 	return func(w *Widget) {
 		w.MinWidth = minWidth
 		w.MinHeight = minHeight
+	}
+}
+
+func (o WidgetOptions) MaxSize(maxWidth int, maxHeight int) WidgetOpt {
+	return func(w *Widget) {
+		w.MaxWidth = maxWidth
+		w.MaxHeight = maxHeight
 	}
 }
 


### PR DESCRIPTION
There is no current functionality for limiting the size of a container, one example where this has been a limitation for me is when a container has rendered larger than the ebiten window size.

In this PR I have added two new properties to the `Container` struct:
(`MaxWidth` and `MaxHeight`), as well as the implemented function `MaxSize()` 

These values are checked in `Container.PreferredSize()`. If they are present, the `w & h` are clamped to be no larger the max size values, this also applies to types that can use alsp this interface.

The usage for `MaxSize()` is as follows 

```golang
const S_WIDTH = 640
const S_HEIGHT = 480

container := widget.NewContainer(
	widget.ContainerOpts.BackgroundImage(
		image.NewNineSliceColor(color.NRGBA{0xff, 0xfa, 0x33, 0xff})
	),
	widget.ContainerOpts.WidgetOpts(
		widget.WidgetOpts.MaxSize(250, S_HEIGHT),
	),
	widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
)

// This Container will never be larger than 250x480
```

I've added a test to ensure that doesn't affect any containers that do not include this widget option