### PR TITLE
chore: move and rename MobileInputMode

### DIFF
--- a/_examples/widget_demos/cut_copy_paste/main.go
+++ b/_examples/widget_demos/cut_copy_paste/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ebitenui/ebitenui"
 	"github.com/ebitenui/ebitenui/image"
 	"github.com/ebitenui/ebitenui/input"
-	"github.com/ebitenui/ebitenui/internal/jsUtil"
+	"github.com/ebitenui/ebitenui/utilities/mobile"
 	"github.com/ebitenui/ebitenui/widget"
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
@@ -59,7 +59,7 @@ func main() {
 		),
 
 		// Set the keyboard type when opened on mobile devices.
-		widget.TextInputOpts.MobileInputMode(jsUtil.TEXT),
+		widget.TextInputOpts.MobileInputMode(mobile.TEXT),
 
 		// Set the Idle and Disabled background image for the text input.
 		// If the NineSlice image has a minimum size, the widget will use that or

--- a/_examples/widget_demos/textinput/main.go
+++ b/_examples/widget_demos/textinput/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ebitenui/ebitenui"
 	"github.com/ebitenui/ebitenui/image"
-	"github.com/ebitenui/ebitenui/internal/jsUtil"
+	"github.com/ebitenui/ebitenui/utilities/mobile"
 	"github.com/ebitenui/ebitenui/widget"
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
@@ -61,7 +61,7 @@ func main() {
 		),
 
 		// Set the keyboard type when opened on mobile devices.
-		widget.TextInputOpts.MobileInputMode(jsUtil.TEXT),
+		widget.TextInputOpts.MobileInputMode(mobile.TEXT),
 
 		//Set the Idle and Disabled background image for the text input
 		//If the NineSlice image has a minimum size, the widget will use that or

--- a/internal/jsUtil/util.go
+++ b/internal/jsUtil/util.go
@@ -4,17 +4,5 @@ type InsertCallBack func(t string) string
 
 type SelectAllCallback func()
 
-type MobileInputMode string
-
-const (
-	TEXT      = MobileInputMode("text")
-	DECIMAL   = MobileInputMode("decimal")
-	NUMERIC   = MobileInputMode("numeric")
-	TELEPHONE = MobileInputMode("tel")
-	SEARCH    = MobileInputMode("search")
-	EMAIL     = MobileInputMode("email")
-	URL       = MobileInputMode("url")
-)
-
 const WASM = "wasm"
 const JS = "js"

--- a/internal/jsUtil/util_notjs.go
+++ b/internal/jsUtil/util_notjs.go
@@ -3,11 +3,13 @@
 
 package jsUtil
 
+import "github.com/ebitenui/ebitenui/utilities/mobile"
+
 func IsMobileBrowser() bool {
 	return false
 }
 
-func Prompt(mode MobileInputMode, title string, value string, cursorPos int, yPos int, callback InsertCallBack, selectAll SelectAllCallback) {
+func Prompt(mode mobile.MobileInputMode, title string, value string, cursorPos int, yPos int, callback InsertCallBack, selectAll SelectAllCallback) {
 
 }
 

--- a/internal/jsUtil/util_notjs.go
+++ b/internal/jsUtil/util_notjs.go
@@ -9,7 +9,7 @@ func IsMobileBrowser() bool {
 	return false
 }
 
-func Prompt(mode mobile.MobileInputMode, title string, value string, cursorPos int, yPos int, callback InsertCallBack, selectAll SelectAllCallback) {
+func Prompt(mode mobile.InputMode, title string, value string, cursorPos int, yPos int, callback InsertCallBack, selectAll SelectAllCallback) {
 
 }
 

--- a/utilities/mobile/inputmode.go
+++ b/utilities/mobile/inputmode.go
@@ -1,13 +1,13 @@
 package mobile
 
-type MobileInputMode string
+type InputMode string
 
 const (
-	TEXT      = MobileInputMode("text")
-	DECIMAL   = MobileInputMode("decimal")
-	NUMERIC   = MobileInputMode("numeric")
-	TELEPHONE = MobileInputMode("tel")
-	SEARCH    = MobileInputMode("search")
-	EMAIL     = MobileInputMode("email")
-	URL       = MobileInputMode("url")
+	TEXT      = InputMode("text")
+	DECIMAL   = InputMode("decimal")
+	NUMERIC   = InputMode("numeric")
+	TELEPHONE = InputMode("tel")
+	SEARCH    = InputMode("search")
+	EMAIL     = InputMode("email")
+	URL       = InputMode("url")
 )

--- a/utilities/mobile/inputmode.go
+++ b/utilities/mobile/inputmode.go
@@ -1,0 +1,13 @@
+package mobile
+
+type MobileInputMode string
+
+const (
+	TEXT      = MobileInputMode("text")
+	DECIMAL   = MobileInputMode("decimal")
+	NUMERIC   = MobileInputMode("numeric")
+	TELEPHONE = MobileInputMode("tel")
+	SEARCH    = MobileInputMode("search")
+	EMAIL     = MobileInputMode("email")
+	URL       = MobileInputMode("url")
+)

--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -35,7 +35,7 @@ type TextInput struct {
 	validationFunc  TextInputValidationFunc
 	placeholderText string
 
-	mobileInputMode mobile.MobileInputMode
+	mobileInputMode mobile.InputMode
 
 	init                  *MultiOnce
 	commandToFunc         map[textInputControlCommand]textInputCommandFunc
@@ -300,7 +300,7 @@ func (o TextInputOptions) SubmitOnEnter(submitOnEnter bool) TextInputOpt {
 // Sets the keyboard type to use when viewed on a mobile browser.
 //
 // https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode
-func (o TextInputOptions) MobileInputMode(mobileInputMode mobile.MobileInputMode) TextInputOpt {
+func (o TextInputOptions) MobileInputMode(mobileInputMode mobile.InputMode) TextInputOpt {
 	return func(t *TextInput) {
 		t.mobileInputMode = mobileInputMode
 	}

--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ebitenui/ebitenui/image"
 	"github.com/ebitenui/ebitenui/input"
 	"github.com/ebitenui/ebitenui/internal/jsUtil"
+	"github.com/ebitenui/ebitenui/utilities/mobile"
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
 )
@@ -34,7 +35,7 @@ type TextInput struct {
 	validationFunc  TextInputValidationFunc
 	placeholderText string
 
-	mobileInputMode jsUtil.MobileInputMode
+	mobileInputMode mobile.MobileInputMode
 
 	init                  *MultiOnce
 	commandToFunc         map[textInputControlCommand]textInputCommandFunc
@@ -132,7 +133,7 @@ func NewTextInput(opts ...TextInputOpt) *TextInput {
 		commandToFunc: map[textInputControlCommand]textInputCommandFunc{},
 		renderBuf:     image.NewMaskedRenderBuffer(),
 
-		mobileInputMode:   jsUtil.TEXT,
+		mobileInputMode:   mobile.TEXT,
 		focusMap:          make(map[FocusDirection]Focuser),
 		submitOnEnter:     true,
 		dragStartIndex:    -1,
@@ -299,7 +300,7 @@ func (o TextInputOptions) SubmitOnEnter(submitOnEnter bool) TextInputOpt {
 // Sets the keyboard type to use when viewed on a mobile browser.
 //
 // https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode
-func (o TextInputOptions) MobileInputMode(mobileInputMode jsUtil.MobileInputMode) TextInputOpt {
+func (o TextInputOptions) MobileInputMode(mobileInputMode mobile.MobileInputMode) TextInputOpt {
 	return func(t *TextInput) {
 		t.mobileInputMode = mobileInputMode
 	}


### PR DESCRIPTION
Currently `jsUtil` package is sourced under `internal` directory. This directory is protected and cannot be depended on by consumer projects.

This PR moves the type `MobileInputMode` under `jsUtil` package from `internal` to within public package `utilities` in order to make `widget.TextInputOpts.MobileInputMode` usable by consumer projects.
