### PR TITLE
Fix missing text label in button option

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -391,14 +391,12 @@ func (o ButtonOptions) TextProcessBBCode(enabled bool) ButtonOpt {
 // TODO: add parameter for image position (start/end).
 func (o ButtonOptions) TextAndImage(label string, face *text.Face, image *GraphicImage, color *ButtonTextColor) ButtonOpt {
 	return func(b *Button) {
-		b.init.Append(func() {
-			b.autoUpdateTextAndGraphic = true
-			b.textLabel = label
-			b.definedParams.TextFace = face
-			b.definedParams.TextColor = color
-			b.definedParams.GraphicImage = image
-			b.definedParams.TextColor = color
-		})
+		b.autoUpdateTextAndGraphic = true
+		b.textLabel = label
+		b.definedParams.TextFace = face
+		b.definedParams.TextColor = color
+		b.definedParams.GraphicImage = image
+		b.definedParams.TextColor = color
 	}
 }
 

--- a/widget/button.go
+++ b/widget/button.go
@@ -393,6 +393,7 @@ func (o ButtonOptions) TextAndImage(label string, face *text.Face, image *Graphi
 	return func(b *Button) {
 		b.init.Append(func() {
 			b.autoUpdateTextAndGraphic = true
+			b.textLabel = label
 			b.definedParams.TextFace = face
 			b.definedParams.TextColor = color
 			b.definedParams.GraphicImage = image


### PR DESCRIPTION
I assume this wasn’t intentional?

I’m not sure why this option uses the `b.Init` multi-once, and not the others, e.g.
```
func (o ButtonOptions) Graphic(image *GraphicImage) ButtonOpt {
	return func(b *Button) {
		b.definedParams.GraphicImage = image
	}
}
```
🤔 