### PR TITLE
Fix text area crash

### DIFF
--- a/widget/textarea.go
+++ b/widget/textarea.go
@@ -590,42 +590,13 @@ func (l *TextArea) initWidget() {
 }
 
 func (l *TextArea) PrependText(value string) {
-	l.text.Label = value + l.text.Label
-
-	if l.showHorizontalSlider {
-		if l.horizontalScrollMode == ScrollBeginning {
-			l.hSlider.Current = 0
-		} else if l.horizontalScrollMode == ScrollEnd {
-			l.hSlider.Current = l.hSlider.Max
-		}
-	}
-	if l.showVerticalSlider {
-		if l.verticalScrollMode == ScrollBeginning {
-			l.vSlider.Current = 0
-		} else if l.verticalScrollMode == ScrollEnd {
-			l.vSlider.Current = l.vSlider.Max
-		}
-	}
+	l.init.Do()
+	l.SetText(value + l.text.Label)
 }
 
 func (l *TextArea) AppendText(value string) {
 	l.init.Do()
-	l.text.Label += value
-
-	if l.showHorizontalSlider {
-		if l.horizontalScrollMode == ScrollBeginning {
-			l.hSlider.Current = 0
-		} else if l.horizontalScrollMode == ScrollEnd {
-			l.hSlider.Current = l.hSlider.Max
-		}
-	}
-	if l.showVerticalSlider {
-		if l.verticalScrollMode == ScrollBeginning {
-			l.vSlider.Current = 0
-		} else if l.verticalScrollMode == ScrollEnd {
-			l.vSlider.Current = l.vSlider.Max
-		}
-	}
+	l.SetText(l.text.Label + value)
 }
 
 func (l *TextArea) SetText(value string) {

--- a/widget/textarea.go
+++ b/widget/textarea.go
@@ -603,14 +603,14 @@ func (l *TextArea) SetText(value string) {
 	l.init.Do()
 	l.text.Label = value
 
-	if l.showHorizontalSlider {
+	if l.showHorizontalSlider && l.hSlider != nil {
 		if l.horizontalScrollMode == ScrollBeginning {
 			l.hSlider.Current = 0
 		} else if l.horizontalScrollMode == ScrollEnd {
 			l.hSlider.Current = l.hSlider.Max
 		}
 	}
-	if l.showVerticalSlider {
+	if l.showVerticalSlider && l.vSlider != nil {
 		if l.verticalScrollMode == ScrollBeginning {
 			l.vSlider.Current = 0
 		} else if l.verticalScrollMode == ScrollEnd {


### PR DESCRIPTION
This fixes a crash in `TextArea.SetText` when called before the first `Update`.

Applying the following patch and running the TextArea example demonstrates the crash.
```
diff --git a/_examples/widget_demos/textarea/main.go b/_examples/widget_demos/textarea/main.go
index 2a9a1b0..86f1d45 100644
--- a/_examples/widget_demos/textarea/main.go
+++ b/_examples/widget_demos/textarea/main.go
@@ -49,6 +49,7 @@ func main() {
 				widget.WidgetOpts.MinSize(300, 100),
 			),
 		),
+		widget.TextAreaOpts.VerticalScrollMode(widget.ScrollEnd),
 		// Set gap between scrollbar and text
 		widget.TextAreaOpts.ControlWidgetSpacing(2),
 		// Tell the textarea to display bbcodes
@@ -111,6 +112,7 @@ func main() {
 	// textarea.SetText("New Value!")
 	// Retrieve the current value of the text area text
 	fmt.Println(textarea.GetText())
+	textarea.SetText("bam\nbam\nbim\nbom\nbam\nbim\nbom\nbam\nbim\nbom\nbam\nbim\nbom\nbam\nbim\nbom\nbam\nbim\nbom\n")
 	// add the textarea as a child of the container
 	rootContainer.AddChild(textarea)
 
```
The length of the set text is merely to make sure the `widget.ScrollEnd` or `widget.ScrollBeginning` options were properly enforced still with the fix.
