### PR TITLE
Add a Window DragEvent

### DIFF
--- a/widget/window.go
+++ b/widget/window.go
@@ -21,6 +21,13 @@ const (
 
 type RemoveWindowFunc func()
 
+type WindowDraggedEventArgs struct {
+	Window *Window
+	Diff   image.Point
+}
+
+type WindowDraggedHandlerFunc func(args *WindowDraggedEventArgs)
+
 type WindowChangedEventArgs struct {
 	Window *Window
 	Rect   image.Rectangle
@@ -36,6 +43,7 @@ type WindowClosedHandlerFunc func(args *WindowClosedEventArgs)
 
 type Window struct {
 	ResizeEvent *event.Event
+	DragEvent   *event.Event
 	MoveEvent   *event.Event
 	ClosedEvent *event.Event
 
@@ -81,6 +89,7 @@ var WindowOpts WindowOptions
 
 func NewWindow(opts ...WindowOpt) *Window {
 	w := &Window{
+		DragEvent:   &event.Event{},
 		MoveEvent:   &event.Event{},
 		ResizeEvent: &event.Event{},
 		ClosedEvent: &event.Event{},
@@ -183,6 +192,17 @@ func (o WindowOptions) MoveHandler(f WindowChangedHandlerFunc) WindowOpt {
 	return func(w *Window) {
 		w.MoveEvent.AddHandler(func(args interface{}) {
 			if arg, ok := args.(*WindowChangedEventArgs); ok {
+				f(arg)
+			}
+		})
+	}
+}
+
+// This handler is triggered when the window is dragged.
+func (o WindowOptions) DragHandler(f WindowDraggedHandlerFunc) WindowOpt {
+	return func(w *Window) {
+		w.DragEvent.AddHandler(func(args interface{}) {
+			if arg, ok := args.(*WindowDraggedEventArgs); ok {
 				f(arg)
 			}
 		})
@@ -320,11 +340,20 @@ func (w *Window) Update(updObj *UpdateObject) {
 
 	if w.dragging {
 		if w.startingPoint.X != x || w.startingPoint.Y != y {
-			newRect := w.container.GetWidget().Rect.Add(image.Point{x - w.startingPoint.X, y - w.startingPoint.Y})
-			w.SetLocation(newRect)
-			w.startingPoint = image.Point{x, y}
+			m := image.Point{x, y}
+			diff := m.Sub(w.startingPoint)
+			rect := w.container.GetWidget().Rect.Add(diff)
+
+			w.SetLocation(rect)
+			w.startingPoint = m
+
+			w.DragEvent.Fire(&WindowDraggedEventArgs{
+				Window: w,
+				Diff:   diff,
+			})
 		}
 	}
+
 	if w.resizing {
 		if w.startingPoint.X != x || w.startingPoint.Y != y {
 			if w.resizingWidth {

--- a/widget/window.go
+++ b/widget/window.go
@@ -310,6 +310,12 @@ func (w *Window) SetupInputLayer(def input.DeferredSetupInputLayerFunc) {
 
 // Typically used internally.
 func (w *Window) Render(screen *ebiten.Image) {
+	w.container.Render(screen)
+}
+
+func (w *Window) Update(updObj *UpdateObject) {
+	w.init.Do()
+
 	x, y := input.CursorPosition()
 
 	if w.dragging {
@@ -357,11 +363,7 @@ func (w *Window) Render(screen *ebiten.Image) {
 			w.resizingHeight = false
 		}
 	}
-	w.container.Render(screen)
-}
 
-func (w *Window) Update(updObj *UpdateObject) {
-	w.init.Do()
 	w.container.Update(updObj)
 }
 


### PR DESCRIPTION
I was trying to implement a draggable window in a tiled game where I wanted the window to be rendered on the tiled grid, even when being dragged. I couldn't find any way to intercept the drag operation, so that the window's rectangle is snapped back to the grid before rendering, so this adds a new event to allow this.

I'm not entirely sure this is the best way to implement this, but this seems to have a relatively small footprint, and it allows my use case. I'd be happy to discuss alternative approaches (including the possibility of me missing something obvious).

The biggest impact here is, I think, that I moved most of the dragging / resizing logic from the window's `Render` function to its `Update` function. I feel like this might be a little controversial, but I did it because otherwise I got jittery output, with the window shaking as I dragged.

I will say, that most of that code was not really render-related, so moving it seemed like a conceptually better solution.