### PR TITLE
widget/gridlayout: Flexible columns when widgets are less than the cols

### DIFF
--- a/widget/gridlayout.go
+++ b/widget/gridlayout.go
@@ -234,7 +234,14 @@ func (g *GridLayout) rowStretched(r int) bool {
 }
 
 func (g *GridLayout) preferredColumnWidthsAndRowHeights(widgets []PreferredSizeLocateableWidget) ([]int, []int) {
-	colWidths := make([]int, g.columns)
+	colLen := g.columns
+	// Check if there are less widgets than columns declared
+	// and if so use the len(widgets) as columns so the sizes
+	// work as epxected
+	if len(widgets) < g.columns {
+		colLen = len(widgets)
+	}
+	colWidths := make([]int, colLen)
 	rowHeights := make([]int, int(math.Ceil(float64(len(widgets))/float64(g.columns))))
 
 	c := 0


### PR DESCRIPTION
When the number of widgets was not the same as the number of columns the sizes where messed up.

This now adapts the cols to the number of widgets until it reaches the number of cols, so a col==3 with 1 widget could still work.

---

When I finished the implementation, I thought that another solution would be to automatically set (if you have 1 widget) 2 more columns (emtpy) of the width of that widget, but I think the current approach is better. 