### PR TITLE
widget: Improved logic of buttons and graphics

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -419,6 +419,7 @@ func (o ButtonOptions) TextPadding(p *Insets) ButtonOpt {
 func (o ButtonOptions) Graphic(image *GraphicImage) ButtonOpt {
 	return func(b *Button) {
 		b.definedParams.GraphicImage = image
+		b.autoUpdateTextAndGraphic = true
 	}
 }
 
@@ -684,14 +685,16 @@ func (b *Button) Render(screen *ebiten.Image) {
 			}
 
 		case b.hovering || b.focused:
-			if b.computedParams.TextColor.Hover != nil {
+			if b.text != nil && b.computedParams.TextColor != nil && b.computedParams.TextColor.Hover != nil {
 				b.text.SetColor(b.computedParams.TextColor.Hover)
 			}
 			if b.computedParams.GraphicImage != nil && b.computedParams.GraphicImage.Hover != nil {
 				b.graphic.Image = b.computedParams.GraphicImage.Hover
 			}
 		default:
-			b.text.SetColor(b.computedParams.TextColor.Idle)
+			if b.text != nil && b.computedParams.TextColor != nil {
+				b.text.SetColor(b.computedParams.TextColor.Idle)
+			}
 		}
 	}
 

--- a/widget/dnd.go
+++ b/widget/dnd.go
@@ -224,6 +224,7 @@ func (d *DragAndDrop) draggingState(srcX int, srcY int, dragWidget *Container, d
 			d.window = NewWindow(
 				WindowOpts.CloseMode(NONE),
 				WindowOpts.Contents(dragWidget),
+				WindowOpts.BlockLower(false),
 			)
 			parent.GetWidget().FireDragAndDropEvent(d.window, true, d)
 		}


### PR DESCRIPTION
Added `b.autoUpdateTextAndGraphic = true` inside the `Graphic()` option function. Without this, the render loop's auto-update block never ran for graphic-only buttons, so changing `GraphicImage.Idle` externally had no visual effect.

Nil guards in `Render()` switch: The hovering/focused and default cases called `b.text.SetColor(...)` unconditionally. Graphic-only buttons have no text widget (b.text == nil), causing a nil pointer panic. 