### PR TITLE
fix: masked-render-buffer image sizes

### DIFF
--- a/image/buffer.go
+++ b/image/buffer.go
@@ -1,6 +1,10 @@
 package image
 
-import "github.com/hajimehoshi/ebiten/v2"
+import (
+	img "image"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
 
 // BufferedImage is a wrapper for an Ebiten Image that helps with caching the Image.
 // As long as Width and Height stay the same, no new Image will be created.
@@ -64,4 +68,41 @@ func (m *MaskedRenderBuffer) Draw(screen *ebiten.Image, d DrawFunc, dm DrawFunc)
 	})
 
 	screen.DrawImage(maskedBuf, nil)
+}
+
+// Draw calls d to draw onto screen, using the mask drawn by dm. The buffer images passed
+// to d and dm are of the same size as screen.
+func (m *MaskedRenderBuffer) DrawTextInput(screen *ebiten.Image, d, dm DrawFunc, rect img.Rectangle) {
+
+	// uses width and height of original input to apply mask
+	// this keeps drawn image at size of input instead of size of screen,
+	// which can be significantly larger
+	// then a translation is applied to move input sized renderBuf to proper location
+
+	x := float64(rect.Min.X)
+	y := float64(rect.Min.Y)
+	w := rect.Dx()
+	h := rect.Dy()
+
+	m.renderBuf.Width, m.renderBuf.Height = w, h
+	renderBuf := m.renderBuf.Image()
+	renderBuf.Clear()
+
+	m.maskedBuf.Width, m.maskedBuf.Height = w, h
+	maskedBuf := m.maskedBuf.Image()
+	maskedBuf.Clear()
+
+	d(renderBuf)
+	dm(maskedBuf)
+
+	maskedBuf.DrawImage(renderBuf, &ebiten.DrawImageOptions{
+		CompositeMode: ebiten.CompositeModeSourceIn,
+	})
+
+	g := ebiten.GeoM{}
+	g.Translate(x, y)
+
+	screen.DrawImage(maskedBuf, &ebiten.DrawImageOptions{
+		GeoM: g,
+	})
 }

--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -833,7 +833,7 @@ func (t *TextInput) renderImage(screen *ebiten.Image) {
 }
 
 func (t *TextInput) renderTextAndCaret(screen *ebiten.Image) {
-	t.renderBuf.Draw(screen,
+	t.renderBuf.DrawTextInput(screen,
 		func(buf *ebiten.Image) {
 			t.drawTextAndCaret(buf)
 		},
@@ -841,14 +841,24 @@ func (t *TextInput) renderTextAndCaret(screen *ebiten.Image) {
 			rect := t.widget.Rect
 			t.mask.Draw(buf, rect.Dx()-t.computedParams.Padding.Left-t.computedParams.Padding.Right, rect.Dy()-t.computedParams.Padding.Top-t.computedParams.Padding.Bottom,
 				func(opts *ebiten.DrawImageOptions) {
-					opts.GeoM.Translate(float64(rect.Min.X+t.computedParams.Padding.Left), float64(rect.Min.Y+t.computedParams.Padding.Top))
+					opts.GeoM.Translate(float64(t.computedParams.Padding.Left), float64(t.computedParams.Padding.Top))
 					opts.CompositeMode = ebiten.CompositeModeCopy
 				})
-		})
+		},
+		t.widget.Rect,
+	)
 }
 
 func (t *TextInput) drawTextAndCaret(screen *ebiten.Image) {
 	rect := t.widget.Rect
+
+	// rebuild origin at 0,0, so we can just apply translate to image instead of using
+	// mask buffer image of screen size, only initial input size
+	rect.Max.X -= rect.Min.X
+	rect.Min.X = 0
+	rect.Max.Y -= rect.Min.Y
+	rect.Min.Y = 0
+
 	tr := rect
 	tr = tr.Add(img.Point{t.computedParams.Padding.Left, t.computedParams.Padding.Top})
 


### PR DESCRIPTION
remove full screen allocation for render buffer and masked buffer, replacing with Text Input sized render and masked buffer, and transformation matrix. May need to complete for scrollable container.

See issue #342

TLDR Makes TextInput significantly more efficient.